### PR TITLE
Make buildable MSVC 64bit

### DIFF
--- a/mecab/.gitignore
+++ b/mecab/.gitignore
@@ -1,0 +1,15 @@
+*.obj
+*.exe
+*.lib
+*.so
+*.pyc
+*.exp
+*.pyc
+*.dll
+*.pdb
+python/build
+python/dist
+python/*.egg-info
+python/.venv
+python/venv
+.vs

--- a/mecab/src/Makefile.x64.msvc
+++ b/mecab/src/Makefile.x64.msvc
@@ -1,0 +1,53 @@
+CC = cl.exe
+CXXC = cl.exe
+LINK=link.exe
+
+CFLAGS = /EHsc /O2 /GL /GA /Ob2 /nologo /W3 /MT /Zi /wd4800 /wd4305 /wd4244
+LDFLAGS = /nologo /OPT:REF /OPT:ICF /LTCG /NXCOMPAT /DYNAMICBASE /MACHINE:X64 ADVAPI32.LIB
+DEFS =  -D_CRT_SECURE_NO_DEPRECATE -DMECAB_USE_THREAD \
+        -DDLL_EXPORT -DHAVE_GETENV -DHAVE_WINDOWS_H -DDIC_VERSION=102 \
+        -DVERSION="\"0.996\"" -DPACKAGE="\"mecab\"" \
+        -DUNICODE -D_UNICODE \
+        -DMECAB_DEFAULT_RC="\"c:\\Program Files\\mecab\\etc\\mecabrc\""
+INC = -I. -I..
+DEL = del
+
+OBJ =   feature_index.obj param.obj  learner.obj string_buffer.obj \
+	char_property.obj         learner_tagger.obj    tagger.obj \
+	connector.obj             tokenizer.obj \
+	context_id.obj            dictionary.obj  utils.obj \
+	dictionary_compiler.obj   viterbi.obj \
+	dictionary_generator.obj  writer.obj iconv_utils.obj \
+	dictionary_rewriter.obj   lbfgs.obj eval.obj nbest_generator.obj
+
+.c.obj:
+	$(CC) $(CFLAGS) $(INC) $(DEFS) -c  $<
+
+.cpp.obj:
+	$(CC) $(CFLAGS) $(INC) $(DEFS) -c  $<
+
+all: libmecab mecab mecab-dict-index mecab-dict-gen mecab-cost-train mecab-system-eval mecab-test-gen
+
+mecab: $(OBJ) mecab.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab.obj libmecab.lib
+
+mecab-dict-index: $(OBJ) mecab-dict-index.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-dict-index.obj libmecab.lib
+
+mecab-dict-gen: $(OBJ) mecab-dict-gen.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-dict-gen.obj libmecab.lib
+
+mecab-cost-train: $(OBJ) mecab-cost-train.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-cost-train.obj libmecab.lib
+
+mecab-system-eval: $(OBJ) mecab-system-eval.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-system-eval.obj libmecab.lib
+
+mecab-test-gen: mecab-test-gen.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-test-gen.obj libmecab.lib
+
+libmecab: $(OBJ) libmecab.obj
+	$(LINK) $(LDFLAGS) /out:$@.dll $(OBJ) libmecab.obj /dll
+
+clean:
+	$(DEL) *.exe *.obj *.dll *.a *.lib *.o *.exp *.def

--- a/mecab/src/Makefile.x86.msvc
+++ b/mecab/src/Makefile.x86.msvc
@@ -1,0 +1,53 @@
+CC = cl.exe
+CXXC = cl.exe
+LINK=link.exe
+
+CFLAGS = /EHsc /O2 /GL /GA /Ob2 /nologo /W3 /MT /Zi /wd4800 /wd4305 /wd4244
+LDFLAGS = /nologo /OPT:REF /OPT:ICF /LTCG /NXCOMPAT /DYNAMICBASE /MACHINE:X86 ADVAPI32.LIB
+DEFS =  -D_CRT_SECURE_NO_DEPRECATE -DMECAB_USE_THREAD \
+        -DDLL_EXPORT -DHAVE_GETENV -DHAVE_WINDOWS_H -DDIC_VERSION=102 \
+        -DVERSION="\"0.996\"" -DPACKAGE="\"mecab\"" \
+        -DUNICODE -D_UNICODE \
+        -DMECAB_DEFAULT_RC="\"c:\\Program Files\\mecab\\etc\\mecabrc\""
+INC = -I. -I..
+DEL = del
+
+OBJ =   feature_index.obj param.obj  learner.obj string_buffer.obj \
+	char_property.obj         learner_tagger.obj    tagger.obj \
+	connector.obj             tokenizer.obj \
+	context_id.obj            dictionary.obj  utils.obj \
+	dictionary_compiler.obj   viterbi.obj \
+	dictionary_generator.obj  writer.obj iconv_utils.obj \
+	dictionary_rewriter.obj   lbfgs.obj eval.obj nbest_generator.obj
+
+.c.obj:
+	$(CC) $(CFLAGS) $(INC) $(DEFS) -c  $<
+
+.cpp.obj:
+	$(CC) $(CFLAGS) $(INC) $(DEFS) -c  $<
+
+all: libmecab mecab mecab-dict-index mecab-dict-gen mecab-cost-train mecab-system-eval mecab-test-gen
+
+mecab: $(OBJ) mecab.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab.obj libmecab.lib
+
+mecab-dict-index: $(OBJ) mecab-dict-index.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-dict-index.obj libmecab.lib
+
+mecab-dict-gen: $(OBJ) mecab-dict-gen.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-dict-gen.obj libmecab.lib
+
+mecab-cost-train: $(OBJ) mecab-cost-train.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-cost-train.obj libmecab.lib
+
+mecab-system-eval: $(OBJ) mecab-system-eval.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-system-eval.obj libmecab.lib
+
+mecab-test-gen: mecab-test-gen.obj
+	$(LINK) $(LDFLAGS) /out:$@.exe mecab-test-gen.obj libmecab.lib
+
+libmecab: $(OBJ) libmecab.obj
+	$(LINK) $(LDFLAGS) /out:$@.dll $(OBJ) libmecab.obj /dll
+
+clean:
+	$(DEL) *.exe *.obj *.dll *.a *.lib *.o *.exp *.def

--- a/mecab/src/common.h
+++ b/mecab/src/common.h
@@ -26,6 +26,7 @@
 #if defined(_MSC_VER) || defined(__CYGWIN__)
 #define NOMINMAX
 #define snprintf _snprintf
+#include <iterator>
 #endif
 
 #define COPYRIGHT "MeCab: Yet Another Part-of-Speech and Morphological Analyzer\n\
@@ -81,13 +82,9 @@
 #define EXIT_SUCCESS 0
 #endif
 
-#ifdef _WIN32
-#ifdef __GNUC__
+#if defined(_WIN32) && (defined(__GNUC__) || defined(_MSC_VER))
 #define WPATH_FORCE(path) (MeCab::Utf8ToWide(path).c_str())
-#define WPATH(path) (path)
-#else
 #define WPATH(path) WPATH_FORCE(path)
-#endif
 #else
 #define WPATH_FORCE(path) (path)
 #define WPATH(path) (path)

--- a/mecab/src/common.h
+++ b/mecab/src/common.h
@@ -82,9 +82,13 @@
 #define EXIT_SUCCESS 0
 #endif
 
-#if defined(_WIN32) && (defined(__GNUC__) || defined(_MSC_VER))
+#ifdef _WIN32
 #define WPATH_FORCE(path) (MeCab::Utf8ToWide(path).c_str())
+#ifdef __GNUC__
+#define WPATH(path) (path)
+#else
 #define WPATH(path) WPATH_FORCE(path)
+#endif
 #else
 #define WPATH_FORCE(path) (path)
 #define WPATH(path) (path)

--- a/mecab/src/feature_index.cpp
+++ b/mecab/src/feature_index.cpp
@@ -353,7 +353,7 @@ bool FeatureIndex::buildUnigramFeature(LearnerPath *path,
               if (!r) goto NEXT;
               os_ << r;
             } break;
-            case 't':  os_ << (size_t)path->rnode->char_type;     break;
+            case 't':  os_ << (unsigned int)path->rnode->char_type;     break;
             case 'u':  os_ << ufeature; break;
             case 'w':
               if (path->rnode->stat == MECAB_NOR_NODE) {

--- a/mecab/src/writer.cpp
+++ b/mecab/src/writer.cpp
@@ -257,7 +257,7 @@ bool Writer::writeNode(Lattice *lattice,
             // input sentence
           case 'S': os->write(lattice->sentence(), lattice->size()); break;
             // sentence length
-          case 'L': *os << lattice->size(); break;
+          case 'L': *os << (unsigned int)lattice->size(); break;
             // morph
           case 'm': os->write(node->surface, node->length); break;
           case 'M': os->write(reinterpret_cast<const char *>


### PR DESCRIPTION
The MSVC build has been broken since `WPATH_FORCE` is not defined for MSVC. 

```
C:\Users\chezo\source\mecab\mecab\src>nmake -f Makefile.msvc

Microsoft(R) Program Maintenance Utility Version 14.16.27023.1
Copyright (C) Microsoft Corporation.  All rights reserved.

        cl.exe /EHsc /O2 /GL /GA /Ob2 /nologo /W3 /MT /Zi /wd4800 /wd4305 /wd4244 -I. -I.. -D_CRT_SECURE_NO_DEPRECATE -DMECAB_USE_THREAD  -DDLL_EXPORT -DHAVE_GETENV -DHAVE_WINDOWS_H -DDIC_VERSION=@DIC_VERSION@  -DVERSION="\"@VERSION@\"" -DPACKAGE="\"mecab\""  -DUNICODE -D_UNICODE  -DMECAB_DEFAULT_RC="\"c:\\Program Files\\mecab\\etc\\mecabrc\"" -c  feature_index.cpp
feature_index.cpp
feature_index.cpp(80): error C3861: 'WPATH_FORCE': 識別子が見つかりませんでした
feature_index.cpp(356): error C2593: 'operator <<' があいまいです。
c:\users\chezo\source\mecab\mecab\src\string_buffer.h(55): note: 'MeCab::StringBuffer &MeCab::StringBuffer::operator <<(unsigned char)' の可能性があります
c:\users\chezo\source\mecab\mecab\src\string_buffer.h(51): note: または 'MeCab::StringBuffer &MeCab::StringBuffer::operator <<(char)'
c:\users\chezo\source\mecab\mecab\src\string_buffer.h(46): note: または 'MeCab::StringBuffer &MeCab::StringBuffer::operator <<(unsigned long)'
c:\users\chezo\source\mecab\mecab\src\string_buffer.h(45): note: または 'MeCab::StringBuffer &MeCab::StringBuffer::operator <<(unsigned int)'
c:\users\chezo\source\mecab\mecab\src\string_buffer.h(44): note: または 'MeCab::StringBuffer &MeCab::StringBuffer::operator <<(unsigned short)'
c:\users\chezo\source\mecab\mecab\src\string_buffer.h(43): note: または 'MeCab::StringBuffer &MeCab::StringBuffer::operator <<(long)'
c:\users\chezo\source\mecab\mecab\src\string_buffer.h(42): note: または 'MeCab::StringBuffer &MeCab::StringBuffer::operator <<(int)'
c:\users\chezo\source\mecab\mecab\src\string_buffer.h(41): note: または 'MeCab::StringBuffer &MeCab::StringBuffer::operator <<(short)'
c:\users\chezo\source\mecab\mecab\src\string_buffer.h(40): note: または 'MeCab::StringBuffer &MeCab::StringBuffer::operator <<(double)'
feature_index.cpp(356): note: 引数リスト '(MeCab::StringBuffer, size_t)' を一致させようとしているとき
feature_index.cpp(454): warning C4267: 'return': 'size_t' から 'int' に変換しました。データが失われているかもしれません。
feature_index.cpp(532): error C3861: 'WPATH_FORCE': 識別子が見つかりませんでした
feature_index.cpp(540): error C3861: 'WPATH_FORCE': 識別子が見つかりませんでした
feature_index.cpp(621): error C3861: 'WPATH_FORCE': 識別子が見つかりませんでした
feature_index.cpp(672): error C3861: 'WPATH_FORCE': 識別子が見つかりませんでした
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\cl.exe"' : リターン コード '0x2'
Stop.
```

This patch fixes 

- Missing `WPATH_FORCE` for MSVC
- Make buildable windows 64bit binaries
- Add Makefile for MSVC since `configure` is not available
