### PR TITLE
Use Appvayor for build for GitHub release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+image: Visual Studio 2017
+
+platform:
+- x64
+
+environment:
+  matrix:
+    - BUILD_TYPE: x86
+    - BUILD_TYPE: x64
+
+build_script:
+    - cd mecab\src
+    - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %BUILD_TYPE%
+    - nmake -f Makefile.%BUILD_TYPE%.msvc
+
+after_build:
+    - cd %APPVEYOR_BUILD_FOLDER%\
+    - 7z a mecab-ko-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\src\*.dll
+    - 7z a mecab-ko-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\src\*.exe
+    - 7z a mecab-ko-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\src\*.lib
+    - 7z a mecab-ko-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\src\mecab.h
+
+artifacts:
+  - path: '*.zip'
+    name: MeCab-MSVC
+deploy:
+  description: 'MeCab-MSVC'
+  provider: GitHub
+  auth_token:
+    secure: wk6H/7XYGdxa7T4A/k+PcHxWngTfJJYAMe2pFVFb7PnMV8vHRSXon9II4EyDomQy
+  artifact: MeCab-MSVC
+  draft: false
+  prerelease: false
+  on:
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,10 +15,10 @@ build_script:
 
 after_build:
     - cd %APPVEYOR_BUILD_FOLDER%\
-    - 7z a mecab-ko-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\src\*.dll
-    - 7z a mecab-ko-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\src\*.exe
-    - 7z a mecab-ko-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\src\*.lib
-    - 7z a mecab-ko-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\src\mecab.h
+    - 7z a mecab-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\mecab\src\*.dll
+    - 7z a mecab-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\mecab\src\*.exe
+    - 7z a mecab-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\mecab\src\*.lib
+    - 7z a mecab-msvc-%BUILD_TYPE%.zip %APPVEYOR_BUILD_FOLDER%\mecab\src\mecab.h
 
 artifacts:
   - path: '*.zip'

--- a/mecab/.gitignore
+++ b/mecab/.gitignore
@@ -7,6 +7,8 @@
 *.pyc
 *.dll
 *.pdb
+*.lo
+*.log
 python/build
 python/dist
 python/*.egg-info

--- a/mecab/src/Makefile.x64.msvc
+++ b/mecab/src/Makefile.x64.msvc
@@ -8,7 +8,7 @@ DEFS =  -D_CRT_SECURE_NO_DEPRECATE -DMECAB_USE_THREAD \
         -DDLL_EXPORT -DHAVE_GETENV -DHAVE_WINDOWS_H -DDIC_VERSION=102 \
         -DVERSION="\"0.996\"" -DPACKAGE="\"mecab\"" \
         -DUNICODE -D_UNICODE \
-        -DMECAB_DEFAULT_RC="\"c:\\Program Files\\mecab\\etc\\mecabrc\""
+        -DMECAB_DEFAULT_RC="\"c:\\mecab\\mecabrc\""
 INC = -I. -I..
 DEL = del
 

--- a/mecab/src/Makefile.x86.msvc
+++ b/mecab/src/Makefile.x86.msvc
@@ -8,7 +8,7 @@ DEFS =  -D_CRT_SECURE_NO_DEPRECATE -DMECAB_USE_THREAD \
         -DDLL_EXPORT -DHAVE_GETENV -DHAVE_WINDOWS_H -DDIC_VERSION=102 \
         -DVERSION="\"0.996\"" -DPACKAGE="\"mecab\"" \
         -DUNICODE -D_UNICODE \
-        -DMECAB_DEFAULT_RC="\"c:\\Program Files\\mecab\\etc\\mecabrc\""
+        -DMECAB_DEFAULT_RC="\"c:\\mecab\\mecabrc\""
 INC = -I. -I..
 DEL = del
 


### PR DESCRIPTION
This PR introduces Appveyor for building .exe, .lib, .dll for both x86 and x64.